### PR TITLE
Bugfix for MSVC and Android CLANG

### DIFF
--- a/midiplay.c
+++ b/midiplay.c
@@ -196,10 +196,11 @@ static int ID(void *id, char *check)
 {
     do
     {
-        if (*(char *)id++ != *check++)
+        if (*(char *)id != *check++)
         {
             return 0;
         }
+        id = (char *)id + 1;        
     }
     while (*check);
 


### PR DESCRIPTION
Hi! I'm working on a Flutter port of Doom and I'm using your player. I ran into a compilation error on Windows (MSVC) and Android (CLANG): "expression must be a pointer to a complete object type".
It was an easy fix, and I thought you might want to integrate this change to make the code more cross-compatible.